### PR TITLE
Extends Constants data structure to differentiate method definitions by visibility

### DIFF
--- a/example/class_with_multiple_method_visibilities.rb
+++ b/example/class_with_multiple_method_visibilities.rb
@@ -1,0 +1,17 @@
+class Foo
+  def public_thing
+    "protected thing"
+  end
+
+  protected
+
+  def protected_thing
+    "protected thing"
+  end
+
+  private
+
+  def private_thing
+    "do something else"
+  end
+end

--- a/test/thanatos_test.rb
+++ b/test/thanatos_test.rb
@@ -8,7 +8,7 @@ class ThanatosTest < Minitest::Test
     thanatos.run
 
     assert_equal [:baz], thanatos.method_calls
-    assert_equal [:bar, :baz, :baq], thanatos.method_definitions
+    assert_equal [:bar, :baz, :baq], thanatos.method_definitions(:public)
     assert_equal 1, thanatos.constants.keys.length
     assert_equal ["Foo"], thanatos.constants.keys.sort
   end
@@ -16,9 +16,9 @@ class ThanatosTest < Minitest::Test
   def test_multiple_classes_method_definitions_and_calls_are_stored
     thanatos = Thanatos.new(path: 'example/multiple_classes.rb')
     thanatos.run
-    
+
     assert_equal [:baz, :baz], thanatos.method_calls
-    assert_equal [:bar, :baz, :baq, :bar, :baz, :baq], thanatos.method_definitions
+    assert_equal [:bar, :baz, :baq, :bar, :baz, :baq], thanatos.method_definitions(:public)
     assert_equal 2, thanatos.constants.keys.length
     assert_equal ["Foo", "Qux"], thanatos.constants.keys.sort
   end
@@ -26,19 +26,19 @@ class ThanatosTest < Minitest::Test
   def test_singleton_method_definitions_and_calls_are_stored
     thanatos = Thanatos.new(path: 'example/singleton_methods.rb')
     thanatos.run
-    
+
     assert_equal [:baz], thanatos.method_calls
-    assert_equal [:bar, :baz, :baq, :bar], thanatos.method_definitions
+    assert_equal [:bar, :baz, :baq, :bar], thanatos.method_definitions(:public)
     assert_equal 1, thanatos.constants.keys.length
     assert_equal ["Foo"], thanatos.constants.keys.sort
   end
 
   def test_multiple_classes_and_nested_namespace_method_definitions_and_calls_are_stored
-    thanatos = Thanatos.new(path: 'example/multiple_classes_and_namespaces.rb') 
+    thanatos = Thanatos.new(path: 'example/multiple_classes_and_namespaces.rb')
     thanatos.run
 
     assert_equal [:baz, :baz, :baz], thanatos.method_calls
-    assert_equal [:bar, :baz, :baq, :bar, :baz, :baq, :bar, :baz, :baq], thanatos.method_definitions
+    assert_equal [:bar, :baz, :baq, :bar, :baz, :baq, :bar, :baz, :baq], thanatos.method_definitions(:public)
     assert_equal 5, thanatos.constants.keys.length
     assert_equal [
       "Foo",
@@ -47,6 +47,16 @@ class ThanatosTest < Minitest::Test
       "Foo::Baz::Bar::Qux",
       "Foo::Qux",
     ], thanatos.constants.keys.sort
+  end
+
+  def test_private_methods_are_differentiated_from_public_ones
+    thanatos = Thanatos.new(path: 'example/class_with_multiple_method_visibilities.rb')
+    thanatos.run
+
+    assert_equal [:public_thing], thanatos.method_definitions(:public)
+    assert_equal [:protected_thing], thanatos.method_definitions(:protected)
+    assert_equal [:private_thing], thanatos.method_definitions(:private)
+    assert_equal 1, thanatos.constants.keys.length
   end
 end
 


### PR DESCRIPTION
This PR extends `Thanatos::Constants` so that we can later identify private and protected methods that are not called within the class.

The underlying hash structure for `Constants` is now:

```ruby
{
  [$CONST_NAME] => { # Methods
    definitions: {
      private: [...],
      protected: [...],
      public: [...],
    },
    calls: [...],
  }
}
```

Co-authored by: @tomajwinter, @katherinlaine, @naeglinghaff, @jamesanthonyt, @jsphmrrw.