### PR TITLE
Implement new API nested by Class

### DIFF
--- a/example/single_class.rb
+++ b/example/single_class.rb
@@ -3,6 +3,8 @@ class Foo
     baz
   end
 
+  private
+
   def baz
     "calling baz"
   end

--- a/lib/thanatos.rb
+++ b/lib/thanatos.rb
@@ -26,11 +26,11 @@ class Thanatos
     end
 
     def definitions(visibility)
-      map { |_, methods| methods.definitions[visibility] }.flatten.compact
+      each_with_object({}) { |(klass, methods), hash| hash[klass] = methods.definitions[visibility] }
     end
 
     def calls
-      map { |_, methods| methods.calls }.flatten.compact
+      each_with_object({}) { |(klass, methods), hash| hash[klass] = methods.calls }
     end
   end
 
@@ -48,6 +48,12 @@ class Thanatos
 
   def method_definitions(visibility)
     constants.definitions(visibility)
+  end
+
+  def unused_private_methods
+    method_definitions(:private).each_with_object({}) do |(key, value), hash|
+      hash[key] = value - method_calls[key]
+    end
   end
 
   def method_calls

--- a/test/thanatos_test.rb
+++ b/test/thanatos_test.rb
@@ -7,18 +7,62 @@ class ThanatosTest < Minitest::Test
     thanatos = Thanatos.new(path: 'example/single_class.rb')
     thanatos.run
 
-    assert_equal [:baz], thanatos.method_calls
-    assert_equal [:bar, :baz, :baq], thanatos.method_definitions(:public)
+    method_calls = { 'Foo' => [:baz] }
+    assert_equal method_calls, thanatos.method_calls
+
+    public_methods = { 'Foo' => [:bar] }
+    assert_equal public_methods, thanatos.method_definitions(:public)
+
+    private_methods = { 'Foo' => [:baz, :baq] }
+    assert_equal private_methods, thanatos.method_definitions(:private)
+
+    unused_private_methods = { 'Foo' => [:baq] }
+    assert_equal unused_private_methods, thanatos.unused_private_methods
+
     assert_equal 1, thanatos.constants.keys.length
     assert_equal ["Foo"], thanatos.constants.keys.sort
+  end
+
+  def test_two_classes_method_definitions_and_called_are_stored
+    thanatos = Thanatos.new(path: 'example/two_classes.rb')
+    thanatos.run
+
+    method_calls = {
+      'Foo' => [:baz],
+      'Table' => []
+    }
+    assert_equal method_calls, thanatos.method_calls
+
+    public_methods = {
+      'Foo' => [:bar],
+      'Table' => [:legs]
+    }
+    assert_equal public_methods, thanatos.method_definitions(:public)
+
+    private_methods = {
+      'Foo' => [:baz, :baq],
+      'Table' => [:stuff]
+    }
+    assert_equal private_methods, thanatos.method_definitions(:private)
+
+    unused_private_methods = {
+      'Foo' => [:baq],
+      'Table' => [:stuff]
+    }
+    assert_equal unused_private_methods, thanatos.unused_private_methods
+
+    assert_equal 2, thanatos.constants.keys.length
+    assert_equal ["Foo", "Table"], thanatos.constants.keys.sort
   end
 
   def test_multiple_classes_method_definitions_and_calls_are_stored
     thanatos = Thanatos.new(path: 'example/multiple_classes.rb')
     thanatos.run
 
-    assert_equal [:baz, :baz], thanatos.method_calls
-    assert_equal [:bar, :baz, :baq, :bar, :baz, :baq], thanatos.method_definitions(:public)
+    method_calls = {"Foo"=>[:baz], "Qux"=>[:baz]}
+    assert_equal method_calls, thanatos.method_calls
+    public_methods = {"Foo"=>[:bar, :baz, :baq], "Qux"=>[:bar, :baz, :baq]}
+    assert_equal public_methods, thanatos.method_definitions(:public)
     assert_equal 2, thanatos.constants.keys.length
     assert_equal ["Foo", "Qux"], thanatos.constants.keys.sort
   end
@@ -26,9 +70,11 @@ class ThanatosTest < Minitest::Test
   def test_singleton_method_definitions_and_calls_are_stored
     thanatos = Thanatos.new(path: 'example/singleton_methods.rb')
     thanatos.run
+    method_calls = {"Foo" => [:baz]}
+    assert_equal method_calls, thanatos.method_calls
 
-    assert_equal [:baz], thanatos.method_calls
-    assert_equal [:bar, :baz, :baq, :bar], thanatos.method_definitions(:public)
+    public_methods = {"Foo" => [:bar, :baz, :baq, :bar]}
+    assert_equal public_methods, thanatos.method_definitions(:public)
     assert_equal 1, thanatos.constants.keys.length
     assert_equal ["Foo"], thanatos.constants.keys.sort
   end
@@ -37,8 +83,11 @@ class ThanatosTest < Minitest::Test
     thanatos = Thanatos.new(path: 'example/multiple_classes_and_namespaces.rb')
     thanatos.run
 
-    assert_equal [:baz, :baz, :baz], thanatos.method_calls
-    assert_equal [:bar, :baz, :baq, :bar, :baz, :baq, :bar, :baz, :baq], thanatos.method_definitions(:public)
+    method_calls = {"Foo"=>[:baz], "Foo::Baz"=>[], "Foo::Baz::Bar"=>[], "Foo::Baz::Bar::Qux"=>[:baz], "Foo::Qux"=>[:baz]}
+    assert_equal method_calls, thanatos.method_calls
+
+    public_methods = {"Foo"=>[:bar, :baz, :baq], "Foo::Baz"=>[], "Foo::Baz::Bar"=>[], "Foo::Baz::Bar::Qux"=>[:bar, :baz, :baq], "Foo::Qux"=>[:bar, :baz, :baq]}
+    assert_equal public_methods, thanatos.method_definitions(:public)
     assert_equal 5, thanatos.constants.keys.length
     assert_equal [
       "Foo",
@@ -53,9 +102,12 @@ class ThanatosTest < Minitest::Test
     thanatos = Thanatos.new(path: 'example/class_with_multiple_method_visibilities.rb')
     thanatos.run
 
-    assert_equal [:public_thing], thanatos.method_definitions(:public)
-    assert_equal [:protected_thing], thanatos.method_definitions(:protected)
-    assert_equal [:private_thing], thanatos.method_definitions(:private)
+    public_methods = {"Foo"=>[:public_thing]}
+    assert_equal public_methods, thanatos.method_definitions(:public)
+    protected_method_definitions = {"Foo"=>[:protected_thing]}
+    assert_equal protected_method_definitions, thanatos.method_definitions(:protected)
+    private_method_definitions = {"Foo"=>[:private_thing]}
+    assert_equal private_method_definitions, thanatos.method_definitions(:private)
     assert_equal 1, thanatos.constants.keys.length
   end
 end


### PR DESCRIPTION
This PR tackles two things

* Implementing a new `unused_private_methods` method that identifies methods under visibility private which are not invoked inside the class
* Changed the API to nest methods, definitions and calls under a parent class key. This covers the case where there is >1 class in a file and we do not want to return a single flat array of `[:foo, :bar]` when these exist on different classes