### PR TITLE
Support for multiple classes with subsequent public methods

### DIFF
--- a/example/multiple_classes_with_public_methods.rb
+++ b/example/multiple_classes_with_public_methods.rb
@@ -1,0 +1,27 @@
+class Foo
+  def bar
+    baz
+  end
+
+  private
+
+  def baz
+    "calling baz"
+  end
+end
+
+class Qux
+  def bar
+    baz
+  end
+
+  def baz
+    "calling baz"
+  end
+
+  private
+
+  def baq
+    "do something else"
+  end
+end

--- a/example/two_classes.rb
+++ b/example/two_classes.rb
@@ -1,0 +1,27 @@
+class Table
+  def legs
+  end
+
+  private
+
+  def stuff
+  end
+end
+
+class Foo
+  public
+
+  def bar
+    baz
+  end
+
+  private
+
+  def baz
+    "calling baz"
+  end
+
+  def baq
+    "do something else"
+  end
+end

--- a/lib/thanatos.rb
+++ b/lib/thanatos.rb
@@ -63,6 +63,7 @@ class Thanatos
   def traverse_prism(node, scope: [])
     case node
     when Prism::ClassNode, Prism::ModuleNode
+      @visibility = :public
       namespace_scope = scope + [node.name]
       constants.find_or_initialize(scope: namespace_scope)
       traverse_children(node, scope: namespace_scope)


### PR DESCRIPTION
Adds an example and fix for the case when there are 2 classes within the same file, and there are public methods in the second. Previously we would assume anything after a private call would be private, but this doesn't hold true in this case. 

The current resolution is to set the default visibility to public upon encountering a class definition.

N.B. Also includes an example file from a previous commit!